### PR TITLE
Agents off line on callback extensions

### DIFF
--- a/modules/cb_extensions/libs/Agentes.class.php
+++ b/modules/cb_extensions/libs/Agentes.class.php
@@ -285,8 +285,10 @@ class Agentes
                     $bMembers = FALSE;
                 elseif ($bMembers) {
                 	$regs = NULL;
-                    if (preg_match('/^\s*(\S+)/', $sLinea, $regs)) {
+                    if (preg_match('/^\s*(\S+\/\S+)/', $sLinea, $regs)) {
                     	if (!in_array($regs[1], $listaAgentes)) $listaAgentes[] = $regs[1];
+                    } else if (preg_match('/^\s*\S+\s+\(\S+\s+from\s+(\S+\/\S+)\)/', $sLinea, $regs)) {
+                        if (!in_array($regs[1], $listaAgentes)) $listaAgentes[] = $regs[1];
                     }
                 }
             }
@@ -324,7 +326,7 @@ class Agentes
             elseif (strpos($sLinea, 'No Callers') !== FALSE || strpos($sLinea, 'Callers:') !== FALSE)
                 $bMembers = FALSE;
             elseif ($bMembers) {
-                if (preg_match('/^\s*(\S+)/', $sLinea, $regs)) {
+	        if (preg_match('/^\s*(\S+\/\S+)/', $sLinea, $regs) || preg_match('/^\s*\S+\s+\(\S+\s+from\s+(\S+\/\S+)\)/', $sLinea, $regs)) {
                     if (!isset($queuesByAgent[$regs[1]]))
                         $queuesByAgent[$regs[1]] = array();
                     $queuesByAgent[$regs[1]][] = $sCurQueue;


### PR DESCRIPTION
Hi,

I'm using call center module with call back extensions and when go to "Call Center", "Agent Options", "Callback Extensions", all agents appears off line and we not able to disconnect.

After debug the web module of call center, i fix the problem with this changes.

I also create the following issue and i'll close:
https://github.com/IssabelFoundation/issabel/issues/34

Regards,
Carlos Rodrigues