### PR TITLE
mejora modulo call center, se puede configurar diferentes callerid uno por campaña para mostrar el numero deseado segun la campaña

### DIFF
--- a/modules/campaign_out/index.php
+++ b/modules/campaign_out/index.php
@@ -150,7 +150,7 @@ function listCampaign($pDB, $smarty, $module_name, $local_templates_dir)
             $arrData[] = array(
                 "<input class=\"button\" type=\"radio\" name=\"id_campaign\" value=\"$campaign[id]\" />",
                 "<a href='?menu=$module_name&amp;action=edit_campaign&amp;id_campaign=".$campaign['id']."'>".
-                    htmlentities($campaign['name'], ENT_COMPAT, 'UTF-8').'</a>',
+                    htmlentities($campaign['name'], ENT_COMPAT, 'UTF-8').'</a>',$campaign['callerid'],
                 $campaign['datetime_init'].' - '.$campaign['datetime_end'],
                 $campaign['daytime_init'].' - '.$campaign['daytime_end'],
                 ($campaign['retries'] != "") ? $campaign['retries'] : "&nbsp;",
@@ -170,7 +170,7 @@ function listCampaign($pDB, $smarty, $module_name, $local_templates_dir)
     $oGrid->setWidth("99%");
     $oGrid->setIcon("images/list.png");
     $oGrid->setURL($url);
-    $oGrid->setColumns(array('', _tr('Name Campaign'), _tr('Range Date'),
+    $oGrid->setColumns(array('', _tr('Name Campaign'),_tr('CallerId'), _tr('Range Date'),
         _tr('Schedule per Day'), _tr('Retries'), _tr('Trunk'), _tr('Queue'),
         _tr('Completed Calls'), _tr('Average Time'), _tr('Status'), _tr('Options')));
     $_POST['cbo_estado']=$sEstado;
@@ -327,6 +327,7 @@ function formEditCampaign($pDB, $smarty, $module_name, $local_templates_dir, $id
         $values_form = NULL;        // Selección hecha en el formulario
         if (is_null($id_campaign)) {
             if (!isset($_POST['nombre'])) $_POST['nombre']='';
+            if (!isset($_POST['callerid'])) $_POST['callerid']='';  
             if (!isset($_POST["context"]) || $_POST["context"]=="") {
                 $_POST["context"] = "from-internal";
             }
@@ -341,6 +342,7 @@ function formEditCampaign($pDB, $smarty, $module_name, $local_templates_dir, $id
 
         } else {
             if (!isset($_POST['nombre']))       $_POST['nombre']       = $arrCampaign[0]['name'];
+            if (!isset($_POST['callerid']))       $_POST['callerid']       = $arrCampaign[0]['callerid'];  
             if (!isset($_POST['fecha_ini']))    $_POST['fecha_ini']    = date('d M Y',strtotime($arrCampaign[0]['datetime_init']));
             if (!isset($_POST['fecha_fin']))    $_POST['fecha_fin']    = date('d M Y',strtotime($arrCampaign[0]['datetime_end']));
             $arrDateTimeInit = explode(":",$arrCampaign[0]['daytime_init']);
@@ -448,7 +450,7 @@ function formEditCampaign($pDB, $smarty, $module_name, $local_templates_dir, $id
                             $time_ini,
                             $time_fin,
                             $_POST['rte_script'],
-                            ($_POST['external_url'] == '') ? NULL : (int)$_POST['external_url']);
+                            ($_POST['external_url'] == '') ? NULL : (int)$_POST['external_url'], $_POST['callerid']);
                         if (is_null($id_campaign)) $bExito = FALSE;
                     } elseif ($bDoUpdate) {
                         $bExito = $oCamp->updateCampaign(
@@ -464,7 +466,7 @@ function formEditCampaign($pDB, $smarty, $module_name, $local_templates_dir, $id
                             $time_ini,
                             $time_fin,
                             $_POST['rte_script'],
-                            ($_POST['external_url'] == '') ? NULL : (int)$_POST['external_url']);
+                            ($_POST['external_url'] == '') ? NULL : (int)$_POST['external_url'], $_POST['callerid']);
                     }
 
                     // Introducir o actualizar formularios
@@ -678,6 +680,14 @@ function getFormCampaign($arrDataTrunks, $arrDataQueues, $arrSelectForm,
             "VALIDATION_TYPE"        => "text",
             "VALIDATION_EXTRA_PARAM" => "",
         ),
+       'callerid'    =>    array(
+	          "LABEL"                => _tr("callerid"),
+	          "REQUIRED"               => "yes",
+	          "INPUT_TYPE"             => "TEXT",
+	          "INPUT_EXTRA_PARAM"      => "",
+	          "VALIDATION_TYPE"        => "numeric",
+	          "VALIDATION_EXTRA_PARAM" => "",
+	      ),
     );
 
     return $formCampos;

--- a/modules/campaign_out/lang/en.lang
+++ b/modules/campaign_out/lang/en.lang
@@ -119,5 +119,7 @@ $arrLangModule = array(
     "Load Contacts for Campaign" => "Load Contacts for Campaign",
     "Available uploaders" => "Available uploaders",
     "Options for" => "Options for",
+    "callerid"=> "CallerID",
+    "Caller ID must be numeric"=> "Caller ID must be numeric"
 );
 ?>

--- a/modules/campaign_out/lang/es.lang
+++ b/modules/campaign_out/lang/es.lang
@@ -109,5 +109,7 @@ $arrLangModule = array(
     "Load Contacts for Campaign" => "Cargar Contactos para Campaña",
     "Available uploaders" => "Cargadores disponibles",
     "Options for" => "Opciones para",
+    "callerid"=> "CallerID",
+    "Caller ID must be numeric"=> "Caller ID debe ser numérico"    
 );
 ?>

--- a/modules/campaign_out/themes/default/new.tpl
+++ b/modules/campaign_out/themes/default/new.tpl
@@ -50,7 +50,7 @@ var rte_script = new richTextEditor('rte_script');
     <table width="900" valign="top" border="0" cellspacing="0" cellpadding="0" class="tabForm">
       <tr height='50'>
           <td width="20%" align='right'>{$nombre.LABEL}: <span  class="required">*</span></td>
-          <td colspan='2'>{$nombre.INPUT}</td>
+          <td colspan='2'>{$nombre.INPUT} &nbsp; {$callerid.LABEL}: <span  class="required">*</span> {$callerid.INPUT}</td>
       </tr>
       <tr>
           <td align='right'>{$fecha_str.LABEL}: <span  class="required">*</span></td>

--- a/setup/call_center.sql
+++ b/setup/call_center.sql
@@ -134,7 +134,8 @@ CREATE TABLE IF NOT EXISTS `calls` (
 
   /* 2015-12-12: Tell apart calls loaded from CSV and scheduled calls */
   `scheduled` BOOLEAN NOT NULL DEFAULT 0,
-
+ `callerid`		int(10) unsigned default NULL,
+	
   PRIMARY KEY  (`id`),
   KEY `id_campaign` (`id_campaign`),
   KEY `calls_ibfk_2` (`id_agent`),
@@ -190,7 +191,8 @@ CREATE TABLE IF NOT EXISTS `campaign` (
     `script`            text NOT NULL,
     `estatus`           varchar(1) NOT NULL default 'A',
     `id_url`            int unsigned,
-
+   `callerid`        int(12) unsigned default NULL,
+	
   PRIMARY KEY  (`id`),
   FOREIGN KEY (id_url)  REFERENCES campaign_external_url(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/setup/call_center.sql
+++ b/setup/call_center.sql
@@ -134,7 +134,7 @@ CREATE TABLE IF NOT EXISTS `calls` (
 
   /* 2015-12-12: Tell apart calls loaded from CSV and scheduled calls */
   `scheduled` BOOLEAN NOT NULL DEFAULT 0,
- `callerid`		int(10) unsigned default NULL,
+ `callerid`		varchar(15) default NULL,
 	
   PRIMARY KEY  (`id`),
   KEY `id_campaign` (`id_campaign`),
@@ -191,7 +191,7 @@ CREATE TABLE IF NOT EXISTS `campaign` (
     `script`            text NOT NULL,
     `estatus`           varchar(1) NOT NULL default 'A',
     `id_url`            int unsigned,
-   `callerid`        int(12) unsigned default NULL,
+   `callerid`        varchar(15) default NULL,
 	
   PRIMARY KEY  (`id`),
   FOREIGN KEY (id_url)  REFERENCES campaign_external_url(id)

--- a/setup/dialer_process/dialer/CampaignProcess.class.php
+++ b/setup/dialer_process/dialer/CampaignProcess.class.php
@@ -342,7 +342,7 @@ PETICION_DESACTIVAR_CADUCAS;
             $sPeticionCampanias = <<<PETICION_CAMPANIAS_SALIENTES
 SELECT id, name, trunk, context, queue, max_canales, num_completadas,
     promedio, desviacion, retries, datetime_init, datetime_end, daytime_init,
-    daytime_end
+    daytime_end, callerid
 FROM campaign
 WHERE datetime_init <= ? AND datetime_end >= ? AND estatus = "A"
     AND (
@@ -794,6 +794,8 @@ SQL_LLAMADA_COLOCADA;
                     "\tTrunk....... ".(is_null($infoCampania['trunk']) ? '(por plan de marcado)' : $infoCampania['trunk'])."\n" .
                     "\tPlantilla... ".$datosTrunk['TRUNK']."\n" .
                     "\tCaller ID... ".(isset($datosTrunk['CID']) ? $datosTrunk['CID'] : "(no definido)")."\n".
+                    "\tCaller ID Trunk. ".$datosTrunk['CID']."\n".
+                    "\tCaller ID campaña.".($infoCampania['callerid'])."\n".               
                     "\tCadena de marcado... {$tupla['dialstring']}\n".
                     "\tTimeout marcado..... ".(is_null($iTimeoutOriginate) ? '(por omisión)' : $iTimeoutOriginate.' ms.'));
             }
@@ -839,7 +841,7 @@ SQL_LLAMADA_COLOCADA;
             $this->_tuberia->AMIEventProcess_ejecutarOriginate(
                 $tupla['actionid'], $iTimeoutOriginate, $iTimestampInicioOriginate,
                 (is_null($tupla['agent']) ? $infoCampania['context'] : 'llamada_agendada'),
-                (isset($datosTrunk['CID']) ? $datosTrunk['CID'] : $tupla['phone']),
+                (isset($infoCampania['callerid']) ? $infoCampania['callerid'] : $datosTrunk['CID']), 
                 $sCadenaVar, (is_null($tupla['retries']) ? 0 : $tupla['retries']) + 1,
                 $infoCampania['trunk']);
         }

--- a/setup/dialer_process/dialer/CampaignProcess.class.php
+++ b/setup/dialer_process/dialer/CampaignProcess.class.php
@@ -753,7 +753,8 @@ PETICION_LLAMADAS;
             }
         }
 
-        // Peticiones preparadas
+$callerid=$infoCampania['callerid'];
+      // Peticiones preparadas
         $sPeticionLlamadaColocada = <<<SQL_LLAMADA_COLOCADA
     UPDATE calls SET status = 'Placing',callerid="$callerid", datetime_originate = ?, fecha_llamada = NULL,
     datetime_entry_queue = NULL, start_time = NULL, end_time = NULL,

--- a/setup/dialer_process/dialer/CampaignProcess.class.php
+++ b/setup/dialer_process/dialer/CampaignProcess.class.php
@@ -755,7 +755,7 @@ PETICION_LLAMADAS;
 
         // Peticiones preparadas
         $sPeticionLlamadaColocada = <<<SQL_LLAMADA_COLOCADA
-UPDATE calls SET status = 'Placing', datetime_originate = ?, fecha_llamada = NULL,
+    UPDATE calls SET status = 'Placing',callerid="$callerid", datetime_originate = ?, fecha_llamada = NULL,
     datetime_entry_queue = NULL, start_time = NULL, end_time = NULL,
     duration_wait = NULL, duration = NULL, failure_cause = NULL,
     failure_cause_txt = NULL, uniqueid = NULL, id_agent = NULL,

--- a/setup/firstboot_call_center.sql
+++ b/setup/firstboot_call_center.sql
@@ -288,6 +288,7 @@ CREATE TABLE `calls` (
   `datetime_originate` datetime DEFAULT NULL,
   `trunk` varchar(20) DEFAULT NULL,
   `scheduled` tinyint(1) NOT NULL DEFAULT '0',
+  `callerid` varchar(15) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `id_campaign` (`id_campaign`),
   KEY `calls_ibfk_2` (`id_agent`),
@@ -373,6 +374,7 @@ CREATE TABLE `campaign` (
   `script` text NOT NULL,
   `estatus` varchar(1) NOT NULL DEFAULT 'A',
   `id_url` int(10) unsigned DEFAULT NULL,
+  `callerid` varchar(15) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `id_url` (`id_url`),
   CONSTRAINT `campaign_ibfk_1` FOREIGN KEY (`id_url`) REFERENCES `campaign_external_url` (`id`)

--- a/setup/installer.php
+++ b/setup/installer.php
@@ -73,6 +73,9 @@ if (file_exists($path_script_db))
     crearColumnaSiNoExiste($pDB, 'call_center', 'campaign',
         'id_url',
         "ADD COLUMN id_url int unsigned, ADD FOREIGN KEY (id_url) REFERENCES campaign_external_url (id)");
+    crearColumnaSiNoExiste($pDB, 'call_center', 'campaign',
+        'callerid',
+        "ADD COLUMN callerid varchar(15) default NULL");
     crearColumnaSiNoExiste($pDB, 'call_center', 'campaign_entry',
         'id_url',
         "ADD COLUMN id_url int unsigned, ADD FOREIGN KEY (id_url) REFERENCES campaign_external_url (id)");
@@ -85,6 +88,9 @@ if (file_exists($path_script_db))
     crearColumnaSiNoExiste($pDB, 'call_center', 'calls',
         'scheduled',
         "ADD COLUMN scheduled BOOLEAN NOT NULL DEFAULT 0");
+    crearColumnaSiNoExiste($pDB, 'call_center', 'calls',
+        'callerid',
+        "ADD COLUMN callerid varchar(15) default NULL");
 
     crearIndiceSiNoExiste($pDB, 'call_center', 'audit',
         'agent_break_datetime',


### PR DESCRIPTION
mejora al crear campañas o editarlas la opción para poder mostrar un callerid en cada campaña o bien en blanco mostraría el que tenga el troncal por defecto. También almacena en cada llamada el callerid indicado para poder saber el numero que se mostró en cada llamada.