### PR TITLE
whisper en monitoreo de campaña con un click

### DIFF
--- a/modules/campaign_monitoring/index.php
+++ b/modules/campaign_monitoring/index.php
@@ -73,6 +73,13 @@ function _moduleContent(&$smarty, $module_name)
 
 function manejarMonitoreo_HTML($module_name, $smarty, $sDirLocalPlantillas)
 {
+//obtenemos la extension actual del usuario activo
+global $arrConf;
+  $pDB = new paloDB($arrConf['issabel_dsn']['acl']);
+    $pACL = new paloACL($pDB);
+$user = $_SESSION['issabel_user'];
+$extension = $pACL->getUserExtension($user);
+
     $smarty->assign("MODULE_NAME", $module_name);
     $smarty->assign(array(
         'title'                         =>  _tr('Campaign Monitoring'),
@@ -106,6 +113,7 @@ function manejarMonitoreo_HTML($module_name, $smarty, $sDirLocalPlantillas)
         'ETIQUETA_MAX_DURAC_LLAM'       =>  _tr('Maximum Call Duration'),
         'ETIQUETA_PROMEDIO_DURAC_LLAM'  =>  _tr('Average Call Duration'),
         'ETIQUETA_OCULTAR_AGENTES'      =>  _tr('Hide Offline Agents'),
+        'EXTENSION_USUARIO'             =>  _tr($extension)	    
     ));
 
     return $smarty->fetch("file:$sDirLocalPlantillas/informacion_campania.tpl");

--- a/modules/campaign_monitoring/libs/escuchar_agente.php
+++ b/modules/campaign_monitoring/libs/escuchar_agente.php
@@ -1,0 +1,43 @@
+<?php
+//hgmnetwork.com 24-08-2018 fichero para realizar una llamada al chanspy con el agente pasado
+//$_GET['agente'] nos da el canal a escuchar sip/5001 o sip/loquesea si es callback y a/5001 o lo que sea si es agente.
+//echo "escuchar al agente: ".$_GET['agente']." en la extension ".$_GET['extension'];
+//obtenemos la primera extension del usuario, en nuestro codigo podemos tener varias extensiones por usuario 7001;7002;7003 o solo una 7001 por derfecto al escucha es en la primera o la unica extension.
+$array_extensiones=explode(";",$_GET['extension']);//pasamos los valores a un array ya que creamos extra para poder tener un usuario varias extensiones separadas por ;
+
+$extension=trim($array_extensiones[0]);
+//a la extension le quitamos el SIP/ o AGENT/ y dejamos solo el numero
+$extension=preg_replace("/(SIP\/|AGENT\/i)/","",$extension);//dejamos solo el numero
+//echo "<hr> la extension del usuario es $array_extensiones[0] y  la del usuario actual es ".$_GET['agente']." <hr>";
+//lo mismo con el agente
+$agente =trim($_GET['agente']);
+$agente=preg_replace("/(SIP\/|AGENT\/)/i","",$agente);//dejamos solo el numero
+
+#permit=127.0.0.1/255.255.255.0,xxx.xxx.xxx.xxx ;(the ip address of the server this page is running on)
+$strHost = "127.0.0.1";
+
+#specify the username you want to login with (these users are defined in /etc/asterisk/manager.conf) o en manager_custom.conf
+#por defecto usamos el usuario de php que viene
+$strUser = "phpconfig";
+
+#specify the password for the above user
+$strSecret = "php[onfig";
+
+$oSocket = fsockopen($strHost, 5038, $errnum, $errdesc) or die("Connection to host failed libs/escuchar_agente.php");
+
+$from = $extension;//quien escucha
+ $to = $agente;//quien es escuchado el agente
+ fputs($oSocket, "Action: Login\r\n");
+ fputs($oSocket, "UserName: $strUser\r\n");
+ fputs($oSocket, "Secret: $strSecret\r\n\r\n");
+ $wrets=fgets($oSocket,128);
+ fputs($oSocket, "Action: Originate\r\n" );
+fputs($oSocket, "CallerId: Whisper Agente: $agente\r\n");
+ fputs($oSocket, "Channel: SIP/".$from."\r\n" );
+ fputs($oSocket, "Application: ChanSpy\r\n" );
+ fputs($oSocket, "Data: SIP/".$to."\r\n\r\n" );
+ $wrets=fgets($oSocket,128);
+ sleep(3);
+
+fclose($oSocket);
+echo "Realizando Whisper al Agente $agente y a la extensión $extension";

--- a/modules/campaign_monitoring/themes/default/informacion_campania.tpl
+++ b/modules/campaign_monitoring/themes/default/informacion_campania.tpl
@@ -138,7 +138,7 @@
                 {literal}{{#view tagName="tbody"}}
                 {{#each agentes}}
                 <tr {{bindAttr class="reciente desde"}}>
-                    <td width="20%" nowrap="nowrap">{{canal}}</td>
+                    <td width="20%" nowrap="nowrap">  OnClick="javascript:escuchar(this.innerHTML,'{/literal}{$EXTENSION_USUARIO}{literal}');"><img src="images/record.png" width="22" height="22" id="escucharAgente"/>{{canal}}</td>
                     <td width="14%" nowrap="nowrap">{{estado}}</td>
                     <td width="23%" nowrap="nowrap">{{numero}}</td>
                     <td width="23%" nowrap="nowrap">{{troncal}}</td>

--- a/modules/campaign_monitoring/themes/default/js/javascript.js
+++ b/modules/campaign_monitoring/themes/default/js/javascript.js
@@ -535,3 +535,33 @@ function mostrar_mensaje_error(s)
 		}, 5000);
 	});
 }
+
+function escuchar(agente,extension){
+        //reemplazamos cualquier etiqueta dejando solo el texto del agente por ejemplo SIP/agente o A/agente Agent/agente SIP/5001 A/5001
+        const regex = /(<([^>]+)>)/ig;
+        var agente = agente.replace(regex, '');
+        //ahora quitamos el espacio inicial o cualquiera
+        var agente = agente.replace(' ', '');
+
+        $.ajax({
+                  url: "/modules/campaign_monitoring/libs/escuchar_agente.php",
+                  type: "get", //send it through get method
+                          data: {
+			    agente: agente,
+                            extension: extension,
+                          },
+
+                          success: function(response) {
+                            //Do Something
+                            console.log(response);
+                          },
+                          error: function(xhr) {
+                            //Do Something to handle error
+                            console.log('error escuchar_agente.php');
+                            console.log(xhr);
+                         alert("Se ha producido un error al intentar escuchar al adengte.")
+                          }
+        });
+
+
+};


### PR DESCRIPTION
con esta mejora en monitoreo de campaña al lado del numero de cada agente aparece un icono y permite al hacer click realizar escucha a ese agente directamente. Es necesario tener el usuario activo con una extensión asignada y esta conectada para que al hacer click emita una llamada al supervisor o la extension que se tenga en ese usuario y este al desconectar, conecta el whisper en modo solo escucha con la extensión indicada.

Si el usuario activo o extension no esta conectada, simplemente se ignora y no hace nada.

Utiliza el usuario de manager_custom.conf  de php (phpconfig).
