### PR TITLE
Añadida opción para tiempo entre llamadas

### DIFF
--- a/modules/callcenter_config/index.php
+++ b/modules/callcenter_config/index.php
@@ -85,7 +85,8 @@ function form_Configuration(&$oDB, $smarty, $module_name, $local_templates_dir)
         'dialer.predictivo' => 'dialer_predictivo',
         'dialer.timeout_originate' => 'dialer_timeout_originate',
         'dialer.timeout_inactivity' => 'dialer_timeout_inactivity',
-       'dialer.forzar_sobrecolocar' => 'dialer_forzar_sobrecolocar',
+        'dialer.forzar_sobrecolocar' => 'dialer_forzar_sobrecolocar',
+        'dialer.entretiempo' => 'dialer_entretiempo',        
     );
     $valoresForm = array(
         'asterisk_asthost' => '127.0.0.1',
@@ -103,6 +104,7 @@ function form_Configuration(&$oDB, $smarty, $module_name, $local_templates_dir)
         'dialer_timeout_originate' => '0',
         'dialer_timeout_inactivity' => '15',
         'dialer_forzar_sobrecolocar' => '0',
+        'dialer_entretiempo' => '0',
     );
     foreach ($camposConocidos as $dbfield => $formfield) {
         if (isset($listaConf[$dbfield])) {
@@ -340,8 +342,16 @@ function createFieldForm()
             'INPUT_EXTRA_PARAM'         =>  '',
             'VALIDATION_EXTRA_PARAM'    =>  '^[[:digit:]]+$',
         ),
-      'dialer_forzar_sobrecolocar'=> array(
+        'dialer_forzar_sobrecolocar'=> array(
             'LABEL'                     =>  _tr('Force more calls per agent'),
+            'REQUIRED'                  =>  'yes',
+            'INPUT_TYPE'                =>  'TEXT',
+            'VALIDATION_TYPE'           =>  'ereg',
+            'INPUT_EXTRA_PARAM'         =>  '',
+            'VALIDATION_EXTRA_PARAM'    =>  '^[[:digit:]]+$',
+        ),
+      	'dialer_entretiempo'  =>  array(
+            'LABEL'                     =>  _tr('Time between calls'),
             'REQUIRED'                  =>  'yes',
             'INPUT_TYPE'                =>  'TEXT',
             'VALIDATION_TYPE'           =>  'ereg',

--- a/modules/callcenter_config/lang/en.lang
+++ b/modules/callcenter_config/lang/en.lang
@@ -51,5 +51,6 @@ $arrLangModule=array(
 'Per-call dial timeout' => 'Per-call dial timeout',
 'Agent inactivity timeout' => 'Agent inactivity timeout',
 'Force more calls per agent' => 'Force more calls per agent',
+'Time between calls' => 'Time between calls',
 );
 ?>

--- a/modules/callcenter_config/themes/default/form.tpl
+++ b/modules/callcenter_config/themes/default/form.tpl
@@ -26,6 +26,8 @@
 <tr class="letra12"><td>{$asterisk_duracion_sesion.INPUT}</td></tr>
 <tr class="letra12"><td>{$dialer_forzar_sobrecolocar.LABEL}:</td></tr>
 <tr class="letra12"><td>{$dialer_forzar_sobrecolocar.INPUT}</td></tr>
+<tr class="letra12"><td>{$dialer_entretiempo.LABEL}:</td></tr>
+<tr class="letra12"><td>{$dialer_entretiempo.INPUT}</td></tr>
 </table>
 </td>
 <td valign="top">

--- a/setup/dialer_process/dialer/CampaignProcess.class.php
+++ b/setup/dialer_process/dialer/CampaignProcess.class.php
@@ -23,7 +23,7 @@
 
 // Número mínimo de muestras para poder confiar en predicciones de marcador
 define('MIN_MUESTRAS', 10);
-define('INTERVALO_REVISION_CAMPANIAS', 3);
+//define('INTERVALO_REVISION_CAMPANIAS', 3);
 
 class CampaignProcess extends TuberiaProcess
 {
@@ -317,8 +317,11 @@ class CampaignProcess extends TuberiaProcess
     {
         // Revisar las campañas cada 3 segundos
         $iTimestamp = time();
-        if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= INTERVALO_REVISION_CAMPANIAS) {
-
+      	if (empty($INTERVALO_REVISION_CAMPANIAS)) {
+			      $INTERVALO_REVISION_CAMPANIAS = $this->_configDB->dialer_entretiempo;
+		    }
+		    if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= $INTERVALO_REVISION_CAMPANIAS) {
+        //if ($iTimestamp - $this->_iTimestampUltimaRevisionCampanias >= INTERVALO_REVISION_CAMPANIAS) {
             /* Se actualiza timestamp de revisión aquí por si no se puede
              * actualizar más tarde debido a una excepción de DB. */
             $this->_iTimestampUltimaRevisionCampanias = $iTimestamp;

--- a/setup/dialer_process/dialer/ConfigDB.class.php
+++ b/setup/dialer_process/dialer/ConfigDB.class.php
@@ -170,7 +170,15 @@ class ConfigDB
                 'mostrar_valor' =>  TRUE,
                 'cast'          =>  'int',
             ),
-
+	    'entretiempo' => array(
+                'descripcion'   =>  'Tiempo de espera entre llamadas',
+                'regex'         =>  '^\d+$',
+                'valor_omision' =>  5,
+                'valor_viejo'   =>  NULL,
+                'valor_actual'  =>  NULL,
+                'mostrar_valor' =>  TRUE,
+                'cast'          =>  'int',
+            ),
 		),
 	);
 


### PR DESCRIPTION
Se agrega opción para permitir la revisión de una campaña y la ejecución de la llamada cada cierta cantidad de segundos, ya que actualmente está quemado en el código 3 segundos.

Esta opción aparecerá en la configuración del callcenter, estará predeterminada a 5 segundos pero el usuario puede cambiarla si lo requiere para ciertos escenarios de operación.