### PR TITLE
Hold/Unhold Button in agent console

### DIFF
--- a/modules/agent_console/index.php
+++ b/modules/agent_console/index.php
@@ -638,6 +638,23 @@ function manejarSesionActiva_HTML($module_name, &$smarty, $sDirLocalPlantillas, 
         $_SESSION['callcenter']['break_iniciado'] = NULL;
     }
 
+     if (($estado['onhold'])) {
+        $smarty->assign(array(
+            'CLASS_BOTON_HOLD'             =>  'issabel-callcenter-boton-unhold',
+            'CLASS_ESTADO_AGENTE_INICIAL'   =>  'issabel-callcenter-class-estado-unhold',
+            'BTN_HOLD'                     =>  _tr('Unhold'),
+            'TEXTO_ESTADO_AGENTE_INICIAL'   =>  _tr('On Hold').': Holding',
+
+        ));
+    } else {
+        $smarty->assign(array(
+            'CLASS_BOTON_HOLD'             =>  'issabel-callcenter-boton-hold',
+            'BTN_HOLD'                     =>  _tr('Hold'),
+            'CLASS_ESTADO_AGENTE_INICIAL'   =>  'issabel-callcenter-class-estado-ocioso',
+            'TEXTO_ESTADO_AGENTE_INICIAL'   =>  _tr('No active call'),
+        ));
+    }
+
     // Cambios según agente conectado a una llamada versus ocioso
     if (!is_null($estado['callinfo'])) {
         // Información sobre la llamada conectada
@@ -929,6 +946,41 @@ function manejarSesionActiva_agentLogout($module_name, $smarty, $sDirLocalPlanti
     return $json->encode($respuesta);
 }
 
+function manejarSesionActiva_hold($module_name, $smarty, $sDirLocalPlantillas, $oPaloConsola, $estado)
+{
+    // echo "<script>alert('You are in hold function');</script>";
+    $respuesta = array(
+        'action'    =>  'hold',
+        'message'   =>  '(no message)',
+    );
+    $bhold = $oPaloConsola->holdCall();
+    if (!$bhold) {
+        $respuesta['action'] = 'error';
+        $respuesta['message'] = _tr('Error while hanging up call').' - '.$oPaloConsola->errMsg;
+    }
+
+    $json = new Services_JSON();
+    Header('Content-Type: application/json');
+    return $json->encode($respuesta);
+}
+
+function manejarSesionActiva_unhold($module_name, $smarty, $sDirLocalPlantillas, $oPaloConsola, $estado)
+{
+    // echo "<script>alert('You are in hold function');</script>";
+    $respuesta = array(
+        'action'    =>  'unhold',
+        'message'   =>  '(no message)',
+    );
+    $bunhold = $oPaloConsola->unholdCall();
+    if (!$bunhold) {
+        $respuesta['action'] = 'error';
+        $respuesta['message'] = _tr('Error while hanging up call').' - '.$oPaloConsola->errMsg;
+    }
+
+    $json = new Services_JSON();
+    Header('Content-Type: application/json');
+    return $json->encode($respuesta);
+}
 function manejarSesionActiva_hangup($module_name, $smarty, $sDirLocalPlantillas, $oPaloConsola, $estado)
 {
     $respuesta = array(
@@ -1588,7 +1640,7 @@ function construirRespuesta_holdenter()
         'event'         =>  'holdenter',
 
         // Etiquetas a modificar en la interfaz
-        'txt_btn_hold' =>  _tr('End Hold'),
+        'txt_btn_hold' =>  _tr('UnHold'),
     );
 }
 

--- a/modules/agent_console/lang/en.lang
+++ b/modules/agent_console/lang/en.lang
@@ -44,6 +44,7 @@ $arrLangModule = array(
 'End Break' => 'End Break',
 'End date' => 'End date',
 'End Hold' => 'End Hold',
+'UnHold' => 'UnHold',
 'End session' => 'End session',
 'End time' => 'End time',
 'Enter' => 'Enter',

--- a/modules/agent_console/libs/paloSantoConsola.class.php
+++ b/modules/agent_console/libs/paloSantoConsola.class.php
@@ -540,6 +540,36 @@ class PaloSantoConsola
         }
     }
 
+    function holdCall()
+    {
+        try {
+            $oECCP = $this->_obtenerConexion('ECCP');
+            $respuesta = $oECCP->hold();
+            if (isset($respuesta->failure)) {
+                $this->errMsg = _tr('Unable to hold call').' - '.$this->_formatoErrorECCP($respuesta);
+                return FALSE;
+            }
+            return TRUE;
+        } catch (Exception $e) {
+            $this->errMsg = '(internal) hold: '.$e->getMessage();
+            return FALSE;
+        }
+    }
+    function unholdCall()
+    {
+        try {
+            $oECCP = $this->_obtenerConexion('ECCP');
+            $respuesta = $oECCP->unhold();
+            if (isset($respuesta->failure)) {
+                $this->errMsg = _tr('Unable to unhold call').' - '.$this->_formatoErrorECCP($respuesta);
+                return FALSE;
+            }
+            return TRUE;
+        } catch (Exception $e) {
+            $this->errMsg = '(internal) unhold: '.$e->getMessage();
+            return FALSE;
+        }
+    }
     /**
      * Método para listar los breaks conocidos en el sistema.
      *

--- a/modules/agent_console/themes/default/agent_console.tpl
+++ b/modules/agent_console/themes/default/agent_console.tpl
@@ -64,6 +64,7 @@
 	    <div id="issabel-callcenter-controles">
 	        <button id="btn_hangup" class="issabel-callcenter-boton-activo">{$BTN_COLGAR_LLAMADA}</button>
 	        <button id="btn_togglebreak" class="{$CLASS_BOTON_BREAK}" >{$BTN_BREAK}</button>
+	        <button id="btn_hold" class="{$CLASS_BOTON_HOLD}" >{$BTN_HOLD}</button>
 	        <button id="btn_transfer" class="issabel-callcenter-boton-activo" >{$BTN_TRANSFER}</button>
             <button id="btn_agendar_llamada" {if $CALLINFO_CALLTYPE != 'outgoing'}disabled="disabled"{/if}>{$BTN_AGENDAR_LLAMADA}</button>
 	        <button id="btn_guardar_formularios">{$BTN_GUARDAR_FORMULARIOS}</button>

--- a/modules/agent_console/themes/default/css/issabel-callcenter.css
+++ b/modules/agent_console/themes/default/css/issabel-callcenter.css
@@ -51,6 +51,9 @@
 .issabel-callcenter-class-estado-break {
     background-color: #BD0000;
 }
+.issabel-callcenter-class-estado-hold {
+    background-color: #ef6400;
+}
 
 td.issabel-callcenter-class-estado-esperando,
 td.issabel-callcenter-class-estado-activo {
@@ -123,6 +126,20 @@ td.issabel-callcenter-class-estado-activo {
 */
 }
 
+.issabel-callcenter-boton-hold {
+    /*
+        width: 95pt;
+        height: 30pt;
+        background-color:#094895;
+    */
+}
+.issabel-callcenter-boton-unhold {
+    /*
+        width: 95pt;
+        height: 30pt;
+        background-color:#BD0000;
+    */
+}
 #issabel-callcenter-llamada-paneles {
     position: relative;
     height: 32em;


### PR DESCRIPTION
adding Hold/Unhold switch button to the agent console
The button is disabled while idle and not in a call, but active on a call
Pressing the Hold button should put the caller on hold and queue member pause agent, and change the name to Unhold
