### PR TITLE
Update Llamada.class.php

### DIFF
--- a/setup/dialer_process/dialer/Llamada.class.php
+++ b/setup/dialer_process/dialer/Llamada.class.php
@@ -540,10 +540,11 @@ class Llamada
         if (!in_array($this->tipo_llamada, array('outgoing')))
             return FALSE;
 
+        $this->status = 'Placing';
         // Notificar el progreso de la llamada
         $paramProgreso = array(
             'datetime_entry'                    =>  date('Y-m-d H:i:s', $timestamp),
-            'new_status'                        =>  'Placing',
+            'new_status'                        =>  $this->status,
             'retry'                             =>  $retry,
             'trunk'                             =>  $trunk,
             'id_campaign_'.$this->tipo_llamada  =>  $this->campania->id,


### PR DESCRIPTION
When originate start a call, the status of the instance is not set, so when callback is executed and the Originate fail, set the status to null when trying to save at database, and fail because the table `call_progress_log` does not allow null at `new_status` column